### PR TITLE
Replace the isDirectory check for userRulesDirectory 

### DIFF
--- a/src/main/java/org/jboss/windup/plugin/WindupMojo.java
+++ b/src/main/java/org/jboss/windup/plugin/WindupMojo.java
@@ -276,7 +276,7 @@ public class WindupMojo extends AbstractMojo
         {
             ArtifactResult artifactResult = mavenContainer.getRepositorySystem().resolveArtifact(session, artifactRequest);
             Path outputDirectory = PathUtil.getWindupRulesDir();
-            if (!Files.isDirectory(Paths.get(userRulesDirectory)))
+            if (!Files.isDirectory(outputDirectory))
                 Files.createDirectories(outputDirectory);
             ZipUtil.unzipToFolder(artifactResult.getArtifact().getFile(), outputDirectory.toFile());
         }


### PR DESCRIPTION
with one for outputDirectory.  This resolves a null pointer exception when you don't specify a userRulesDirectory.