### PR TITLE
Revert release to 5.2.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.jboss.windup.plugin</groupId>
     <artifactId>windup-maven-plugin</artifactId>
-    <version>5.3.0.Alpha1</version>
+    <version>5.2.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Windup Maven Plugin</name>
@@ -29,7 +29,7 @@
    </prerequisites>
    
     <scm>
-        <tag>5.3.0.Alpha1</tag>
+        <tag>master</tag>
         <url>http://github.com/windup/windup-maven-plugin</url>
         <connection>scm:git:https://github.com/windup/windup-maven-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:windup/windup-maven-plugin.git</developerConnection>
@@ -74,7 +74,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
 
-        <version.windupcore>5.3.0-SNAPSHOT</version.windupcore>
+        <version.windupcore>5.2.2-SNAPSHOT</version.windupcore>
         <version.windup-rulesets>${version.windupcore}</version.windup-rulesets>
         <!-- For now, we need to pass this to the Mojo explicitly (through META-INF/versions.properties),
              but it should be possible to figure that out from the Windup POM. -->

--- a/src/it/simple-it/pom.xml
+++ b/src/it/simple-it/pom.xml
@@ -5,13 +5,13 @@
 
   <groupId>org.jboss.windup.plugin.it</groupId>
   <artifactId>simple-it</artifactId>
-  <version>5.3.0-SNAPSHOT</version>
+  <version>5.2.2-SNAPSHOT</version>
 
   <description>A simple IT verifying the basic use case.</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.windupcore>5.3.0-SNAPSHOT</version.windupcore>
+    <version.windupcore>5.2.2-SNAPSHOT</version.windupcore>
     <version.forge>3.7.2.Final</version.forge>
     <inputDirectory>${project.basedir}/../../../</inputDirectory>
     <outputDirectory>${project.build.directory}/windup-report</outputDirectory>
@@ -22,7 +22,7 @@
       <plugin>
         <groupId>org.jboss.windup.plugin</groupId>
         <artifactId>windup-maven-plugin</artifactId>
-        <version>5.3.0-SNAPSHOT</version>
+        <version>5.2.2-SNAPSHOT</version>
         <executions>
           <execution>
             <id>run-windup</id>

--- a/src/test/java/org/jboss/windup/plugin/WindupMojoTest.java
+++ b/src/test/java/org/jboss/windup/plugin/WindupMojoTest.java
@@ -76,6 +76,6 @@ public class WindupMojoTest extends AbstractMojoTestCase
         mojo2.execute();
 
 
-        assertEquals(mojo2.getWindupVersion(), "5.3.0-SNAPSHOT");
+        assertEquals(mojo2.getWindupVersion(), "5.2.2-SNAPSHOT");
     }
 }

--- a/src/test/resources/mojoTestConfig.xml
+++ b/src/test/resources/mojoTestConfig.xml
@@ -4,7 +4,7 @@
             <plugin>
                 <groupId>org.jboss.windup.plugin</groupId>
                 <artifactId>windup-maven-plugin</artifactId>
-                <version>5.3.0-SNAPSHOT</version>
+                <version>5.2.2-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>run-windup</id>

--- a/src/test/resources/mojoTestConfigWithWindupVersion.xml
+++ b/src/test/resources/mojoTestConfigWithWindupVersion.xml
@@ -33,7 +33,7 @@
                     <outputDirectory>target</outputDirectory>
                     <offlineMode>true</offlineMode>
                     <overwrite>false</overwrite>
-                    <windupVersion>5.3.0-SNAPSHOT</windupVersion>
+                    <windupVersion>5.2.2-SNAPSHOT</windupVersion>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
See [failed build job](https://main-jenkins-csb-windup.apps.ocp4.prod.psi.redhat.com/view/windup-release-pipeline/job/windup-maven-plugin-release/47/)