### PR TITLE
WINDUP-3602 Run project's tests on JDK 11 and 17

### DIFF
--- a/.github/workflows/pull_request_push_build.yml
+++ b/.github/workflows/pull_request_push_build.yml
@@ -87,7 +87,13 @@ jobs:
       run: mvn clean install -B -D"maven.repo.local=.m2"
 
   windup-maven-plugin-build-tmp:
-    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk-distribution: [ temurin ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        java-version: [ 11, 17 ]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout windup project
         uses: actions/checkout@v3
@@ -105,11 +111,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: windup-maven-plugin
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'temurin'
+          java-version: ${{ matrix.java-version }}
+          distribution: ${{ matrix.jdk-distribution }}
           cache: 'maven'
       - name: Build Windup dependencies
         run: |

--- a/.github/workflows/pull_request_push_build.yml
+++ b/.github/workflows/pull_request_push_build.yml
@@ -11,16 +11,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk-distribution: [ adopt, temurin ]
+        jdk-distribution: [ temurin ]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        java-version: [ 11, 17 ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3.0.2
+      uses: actions/checkout@v3
     - name: Set up JDK 11
-      uses: actions/setup-java@v3.3.0
+      uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: ${{ matrix.java-version }}
         distribution: ${{ matrix.jdk-distribution }}
         cache: 'maven'
     - name: Maven build

--- a/.github/workflows/pull_request_push_build.yml
+++ b/.github/workflows/pull_request_push_build.yml
@@ -7,7 +7,57 @@ on:
     branches: [ master ]
 
 jobs:
+
   windup-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: windup/windup
+          ref: ${{ github.base_ref }}
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          java-package: jdk
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: maven-windup-build-${{ github.sha }}
+          restore-keys:
+            maven-windup-build
+      - name: Build on JDK 11
+        run: mvn -B clean install -DskipTests
+
+  windup-rulesets-build:
+    runs-on: ubuntu-latest
+    needs: [windup-build]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: windup/windup-rulesets
+          ref: ${{ github.base_ref }}
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          java-package: jdk
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: maven-windup-rulesets-build-${{ github.sha }}
+          restore-keys: |
+            maven-windup-build-${{ github.sha }}
+      - name: Build for the windup-maven-plugin-build
+        run: mvn clean install -nsu -DskipTests
+
+  windup-maven-plugin-build:
     strategy:
       fail-fast: false
       matrix:
@@ -15,6 +65,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         java-version: [ 11, 17 ]
     runs-on: ${{ matrix.os }}
+    needs: [windup-rulesets-build]
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -23,6 +74,12 @@ jobs:
       with:
         java-version: ${{ matrix.java-version }}
         distribution: ${{ matrix.jdk-distribution }}
-        cache: 'maven'
+    - name: Cache local Maven repository
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        key: maven-windup-maven-plugin-build-${{ github.sha }}
+        restore-keys: |
+          maven-windup-rulesets-build-${{ github.sha }}
     - name: Maven build
       run: mvn clean install -B -s build/settings.xml -Dorg.apache.maven.user-settings=build/settings.xml

--- a/.github/workflows/pull_request_push_build.yml
+++ b/.github/workflows/pull_request_push_build.yml
@@ -2,91 +2,15 @@ name: Windup PR builder
 
 on:
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - 'releases/**'
   push:
     branches: [ master ]
 
 jobs:
 
-  windup-build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          repository: windup/windup
-          ref: ${{ github.base_ref }}
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          java-package: jdk
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: .m2
-          key: maven-windup-build-${{ github.sha }}
-          restore-keys:
-            maven-windup-build
-      - name: Build on JDK 11
-        run: mvn -B clean install -DskipTests -Dmaven.repo.local=.m2
-
-  windup-rulesets-build:
-    runs-on: ubuntu-latest
-    needs: [windup-build]
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          repository: windup/windup-rulesets
-          ref: ${{ github.base_ref }}
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          java-package: jdk
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: .m2
-          key: maven-windup-rulesets-build-${{ github.sha }}
-          restore-keys: |
-            maven-windup-build-${{ github.sha }}
-      - name: Build for the windup-maven-plugin-build
-        run: mvn clean install -nsu -DskipTests -Dmaven.repo.local=.m2
-
   windup-maven-plugin-build:
-    strategy:
-      fail-fast: false
-      matrix:
-        jdk-distribution: [ temurin ]
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        java-version: [ 11, 17 ]
-    runs-on: ${{ matrix.os }}
-    needs: [windup-rulesets-build]
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{ matrix.java-version }}
-        distribution: ${{ matrix.jdk-distribution }}
-        java-package: jdk
-    - name: Cache local Maven repository
-      uses: actions/cache@v3
-      with:
-        path: .m2
-        enableCrossOsArchive: true
-        key: maven-windup-maven-plugin-build-${{ github.sha }}
-        restore-keys: |
-          maven-windup-rulesets-build-${{ github.sha }}
-    - name: Maven build
-      run: mvn clean install -B -D"maven.repo.local=.m2"
-
-  windup-maven-plugin-build-tmp:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pull_request_push_build.yml
+++ b/.github/workflows/pull_request_push_build.yml
@@ -30,7 +30,7 @@ jobs:
           restore-keys:
             maven-windup-build
       - name: Build on JDK 11
-        run: mvn -B clean install -DskipTests
+        run: mvn -B clean install -DskipTests -Dmaven.repo.local=.m2
 
   windup-rulesets-build:
     runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
           restore-keys: |
             maven-windup-build-${{ github.sha }}
       - name: Build for the windup-maven-plugin-build
-        run: mvn clean install -nsu -DskipTests
+        run: mvn clean install -nsu -DskipTests -Dmaven.repo.local=.m2
 
   windup-maven-plugin-build:
     strategy:
@@ -83,4 +83,4 @@ jobs:
         restore-keys: |
           maven-windup-rulesets-build-${{ github.sha }}
     - name: Maven build
-      run: mvn clean install -B -s build/settings.xml -Dorg.apache.maven.user-settings=build/settings.xml
+      run: mvn clean install -B -s build/settings.xml -D"org.apache.maven.user-settings=build/settings.xml" -D"maven.repo.local=.m2"

--- a/.github/workflows/pull_request_push_build.yml
+++ b/.github/workflows/pull_request_push_build.yml
@@ -74,6 +74,7 @@ jobs:
       with:
         java-version: ${{ matrix.java-version }}
         distribution: ${{ matrix.jdk-distribution }}
+        java-package: jdk
     - name: Cache local Maven repository
       uses: actions/cache@v3
       with:
@@ -83,4 +84,36 @@ jobs:
         restore-keys: |
           maven-windup-rulesets-build-${{ github.sha }}
     - name: Maven build
-      run: mvn clean install -B -s build/settings.xml -D"maven.repo.local=.m2"
+      run: mvn clean install -B -D"maven.repo.local=.m2"
+
+  windup-maven-plugin-build-tmp:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout windup project
+        uses: actions/checkout@v3
+        with:
+          repository: windup/windup
+          ref: ${{ github.base_ref }}
+          path: windup
+      - name: Checkout windup-rulesets project
+        uses: actions/checkout@v3
+        with:
+          repository: windup/windup-rulesets
+          ref: ${{ github.base_ref }}
+          path: windup-rulesets
+      - name: Checkout PR code
+        uses: actions/checkout@v3
+        with:
+          path: windup-maven-plugin
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Build Windup dependencies
+        run: |
+          mvn install -DskipTests -f windup
+          mvn install -DskipTests -f windup-rulesets
+      - name: Maven build
+        run: mvn clean install -B -f windup-maven-plugin

--- a/.github/workflows/pull_request_push_build.yml
+++ b/.github/workflows/pull_request_push_build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:
-          path: ~/.m2/repository
+          path: .m2
           key: maven-windup-build-${{ github.sha }}
           restore-keys:
             maven-windup-build
@@ -50,7 +50,7 @@ jobs:
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:
-          path: ~/.m2/repository
+          path: .m2
           key: maven-windup-rulesets-build-${{ github.sha }}
           restore-keys: |
             maven-windup-build-${{ github.sha }}
@@ -77,7 +77,8 @@ jobs:
     - name: Cache local Maven repository
       uses: actions/cache@v3
       with:
-        path: ~/.m2/repository
+        path: .m2
+        enableCrossOsArchive: true
         key: maven-windup-maven-plugin-build-${{ github.sha }}
         restore-keys: |
           maven-windup-rulesets-build-${{ github.sha }}

--- a/.github/workflows/pull_request_push_build.yml
+++ b/.github/workflows/pull_request_push_build.yml
@@ -83,4 +83,4 @@ jobs:
         restore-keys: |
           maven-windup-rulesets-build-${{ github.sha }}
     - name: Maven build
-      run: mvn clean install -B -s build/settings.xml -D"org.apache.maven.user-settings=build/settings.xml" -D"maven.repo.local=.m2"
+      run: mvn clean install -B -s build/settings.xml -D"maven.repo.local=.m2"

--- a/README.adoc
+++ b/README.adoc
@@ -33,11 +33,16 @@ mvn clean install
 
 An example showing how to use the plugin can be found https://github.com/windup/windup-maven-plugin/blob/master/src/it/simple-it/pom.xml[here].
 
-More examples will be provided as well the list of all atributes that can be used by the plugin.
+More examples will be provided as well the list of all attributes that can be used by the plugin.
 
-NOTE: In order to run it on JDK 11, you first need to set the MAVEN_OPTS on the command line to load the *java.se* module
+NOTE: In order to run it on JDK 11, you first need to set the MAVEN_OPTS on the command line to load the *java.se* module running:
 ----
 export MAVEN_OPTS="--add-modules=java.se"
+----
+
+NOTE: In order to run it on JDK 17, you first need to set the MAVEN_OPTS on the command line running:
+----
+export MAVEN_OPTS="--add-modules=java.se  --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.stream=ALL-UNNAMED"
 ----
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.8.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -107,17 +107,17 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.8.1</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.8.1</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.2</version>
+            <version>3.8.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -279,8 +279,9 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0</version>
                         <configuration>
-                            <argLine>--add-modules=java.se</argLine>
+                            <argLine>--add-modules=java.se --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.stream=ALL-UNNAMED</argLine>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/windup-plugin/src/test/java/org/jboss/windup/plugin/WindupMojoTest.java
+++ b/windup-plugin/src/test/java/org/jboss/windup/plugin/WindupMojoTest.java
@@ -46,7 +46,16 @@ public class WindupMojoTest extends AbstractMojoTestCase
                 "src/test/resources/mojoTestConfig.xml" );
         assertNotNull(testPom);
 
-        WindupMojo mojo = (WindupMojo)lookupMojo("windup", testPom);
+        MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
+        MavenExecutionRequestPopulator populator = getContainer().lookup( MavenExecutionRequestPopulator.class );
+        populator.populateDefaults(executionRequest);
+        executionRequest.setSystemProperties(System.getProperties());
+
+        ProjectBuildingRequest buildingRequest = executionRequest.getProjectBuildingRequest();
+        ProjectBuilder projectBuilder = this.lookup(ProjectBuilder.class);
+        MavenProject project = projectBuilder.build(testPom, buildingRequest).getProject();
+
+        WindupMojo mojo = (WindupMojo) lookupConfiguredMojo(project, "windup");
         assertNotNull( mojo );
         assertNull(mojo.getWindupVersion());
         mojo.execute();

--- a/windup-plugin/src/test/resources/mojoTestConfig.xml
+++ b/windup-plugin/src/test/resources/mojoTestConfig.xml
@@ -1,4 +1,12 @@
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.windup.plugin.it</groupId>
+    <artifactId>simple-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3602
closes #42 

I've created "siloed" jobs because the tentative of having single shared builds for `windup` and `windup-rulesets` projects didn't work. The reason is that for having the shared builds, `actions/cache` requires a relative, OS-neutral (e.g. no `~` usage, ref.) value for the `path` option and then this value must be provided as input to the build using the `-D"maven.repo.local=.m2"` CLI option.
This means to have the `.m2` folder in the root folder of the project.
The issue comes for Forge/Furnace that reads this property value (i.e. `.m2`) but it's applied when building a specific plugin (e.g. `windup-plugin`) so the `.m2` folder used from Forge/Furnace will be `windup-plugin/.m2` hence nothing will be available in such a folder so the build fails in deploying the required Forge addons.